### PR TITLE
Bump SDK version to 2.4.0

### DIFF
--- a/src/static/checkout.html
+++ b/src/static/checkout.html
@@ -10,10 +10,10 @@
     </style>
     <link
       rel="stylesheet"
-      href="https://sdk.primer.io/web/v2.0.0/Checkout.css"
+      href="https://sdk.primer.io/web/v2.4.0/Checkout.css"
     />
     <script
-      src="https://sdk.primer.io/web/v2.0.0/Primer.min.js"
+      src="https://sdk.primer.io/web/v2.4.0/Primer.min.js"
       crossorigin="anonymous"
     ></script>
     <link rel="stylesheet" href="/static/style.css" />


### PR DESCRIPTION
Use most recent SDK version 2.4.0 – see [changelog](https://primerio.notion.site/Web-SDK-fa20ef5e42c3478fa00521192925a5c6#7c110ca2f3db4ad48240a3282980f8ef)