### PR TITLE
Added missing customer fields for 3DS to work

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -52,6 +52,7 @@ app.post('/client-session', async (req, res) => {
       // 3-character Currency Code used for all the amount of this session
       currencyCode: 'EUR',
 
+      // emailAddress and billingAddress are required for 3DS
       customer: {
         emailAddress: "test@test.com",
         mobileNumber: "+6588889999",

--- a/src/server.js
+++ b/src/server.js
@@ -52,6 +52,22 @@ app.post('/client-session', async (req, res) => {
       // 3-character Currency Code used for all the amount of this session
       currencyCode: 'EUR',
 
+      customer: {
+        emailAddress: "test@test.com",
+        mobileNumber: "+6588889999",
+        firstName: "John",
+        lastName: "Smith",
+        billingAddress: {
+          firstName: "John",
+          lastName: "Smith",
+          postalCode: "CB94BQ",
+          addressLine1: "47A",
+          countryCode: "CL",
+          city: "Cambridge",
+          state: "Cambridgeshire"
+        }
+      },
+
       order: {
         // Line items for this session
         // If your checkout does not have line items:


### PR DESCRIPTION
Per [testing 3DS document](https://primer.io/docs/accept-payments/three-d-secure/testing-three-d-secure) `billingAddress` and `emailAddress` are mandatory for 3DS to work. This makes an example work with 3DS out of the box.